### PR TITLE
feat(export): add variant and price filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ package
 .project
 exported.csv
 .idea
+DE-product-template.csv
+DE-product.csv
+DE-productfamily-template.csv

--- a/README.md
+++ b/README.md
@@ -365,16 +365,18 @@ productType,name.en,variantId
 
   Options:
 
-    -h, --help                 output usage information
-    -t, --template <file>      CSV file containing your header that defines what you want to export
-    -o, --out <file>           Path to the file the exporter will write the resulting CSV in
-    -j, --json                 Export in JSON format
-    -q, --queryString <query>  Query string to specify the sub-set of products to export
-    -l, --language [lang]      Language used on export for localised attributes (except lenums) and category names (default is en)
-    --queryType <type>         Whether to do a query or a search request
-    --queryEncoded             Whether the given query string is already encoded or not
-    --fillAllRows              When given product attributes like name will be added to each variant row.
-    --categoryBy               Define which identifier should be used to for the categories column - either slug or externalId. If nothing given the named path is used.
+    -h, --help                    output usage information
+    -t, --template <file>         CSV file containing your header that defines what you want to export
+    -o, --out <file>              Path to the file the exporter will write the resulting CSV in
+    -j, --json                    Export in JSON format
+    -q, --queryString <query>     Query string to specify the sub-set of products to export
+    -l, --language [lang]         Language used on export for localised attributes (except lenums) and category names (default is en)
+    --queryType <type>            Whether to do a query or a search request
+    --queryEncoded                Whether the given query string is already encoded or not
+    --fillAllRows                 When given product attributes like name will be added to each variant row.
+    --categoryBy                  Define which identifier should be used to for the categories column - either slug or externalId. If nothing given the named path is used.
+    --filterVariantsByAttributes  Query string to filter variants of products
+    --filterPrices  Query string to filter prices of variants
 ```
 
 #### Export as JSON

--- a/src/coffee/export.coffee
+++ b/src/coffee/export.coffee
@@ -76,11 +76,12 @@ class Export
 
     # filter prices of filtered variants
     return _.map(filteredVariants, (variant) =>
-      variant.prices = @_filterPrices(
-        variant.prices,
-        @queryOptions.filterPrices
-      )
-      if variant.prices.length == 0 then return null
+      if @queryOptions.filterPrices?.length > 0
+        variant.prices = @_filterPrices(
+          variant.prices,
+          @queryOptions.filterPrices
+        )
+        if variant.prices.length == 0 then return null
       return variant
     )
 

--- a/src/coffee/export.coffee
+++ b/src/coffee/export.coffee
@@ -60,16 +60,19 @@ class Export
 
   _filterVariantsByAttributes: (variants, filter) ->
     filteredVariants = _.filter(variants, (variant) ->
-      return _.reduce(
-        filter,
-        (filterOutVariant, filter) ->
-          # filter attributes
-          attribute = _.findWhere(variant.attributes, {
-            name: filter.name
-          })
-          return filterOutVariant && !!attribute &&
-            (attribute.value == filter.value)
-      , true)
+      return if filter?.length > 0
+        _.reduce(
+          filter,
+          (filterOutVariant, filter) ->
+            # filter attributes
+            attribute = _.findWhere(variant.attributes, {
+              name: filter.name
+            })
+            return filterOutVariant && !!attribute &&
+              (attribute.value == filter.value)
+        , true)
+      else
+        true
     )
 
     # filter prices of filtered variants

--- a/src/coffee/export.coffee
+++ b/src/coffee/export.coffee
@@ -19,7 +19,6 @@ class Export
   constructor: (@options = {}) ->
     @queryOptions =
       queryString: @options.export?.queryString?.trim()
-      queryType: @options.export?.queryType
       isQueryEncoded: @options.export?.isQueryEncoded
       filterVariantsByAttributes: @_parseQuery(
         @options.export?.filterVariantsByAttributes
@@ -100,14 +99,7 @@ class Export
     productsService = @client.productProjections
     if @queryOptions.queryString
       productsService.byQueryString(@queryOptions.queryString, @queryOptions.isQueryEncoded)
-      if @queryOptions.queryType is 'search'
-        # FIXME: this doesn't work with methods like `process`
-        # as the base resource endpoint will be used
-        # (in this case `/product-projections`).
-        # Should be fixed upstream in the `node-sdk`.
-        productsService.asSearch()
-      else
-        productsService
+      productsService
     else
       productsService.all().perPage(500).staged(staged)
 

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -281,7 +281,6 @@ module.exports = class
       .option '-j, --json', 'Export in JSON format'
       .option '-q, --queryString <query>', 'Query string to specify the sub-set of products to export'
       .option '-l, --language [lang]', 'Language used on export for localised attributes (except lenums) and category names (default is en)'
-      .option '--queryType <type>', 'Whether to do a query or a search request', 'query'
       .option '--queryEncoded', 'Whether the given query string is already encoded or not', false
       .option '--fillAllRows', 'When given product attributes like name will be added to each variant row.'
       .option '--categoryBy <name>', 'Define which identifier should be used to for the categories column - either slug or externalId. If nothing given the named path is used.'
@@ -304,7 +303,6 @@ module.exports = class
             export:
               show_progress: true
               queryString: opts.queryString
-              queryType: opts.queryType
               isQueryEncoded: opts.queryEncoded or false
               filterVariantsByAttributes: opts.filterVariantsByAttributes
               filterPrices: opts.filterPrices

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -285,6 +285,8 @@ module.exports = class
       .option '--queryEncoded', 'Whether the given query string is already encoded or not', false
       .option '--fillAllRows', 'When given product attributes like name will be added to each variant row.'
       .option '--categoryBy <name>', 'Define which identifier should be used to for the categories column - either slug or externalId. If nothing given the named path is used.'
+      .option '--filterVariantsByAttributes <query>', 'Query string to filter variants of products', 'query'
+      .option '--filterPrices <query>', 'Query string to filter prices of products', 'query'
       .usage '--projectKey <project-key> --clientId <client-id> --clientSecret <client-secret> --template <file> --out <file>'
       .action (opts) =>
         GLOBALS.DEFAULT_LANGUAGE = opts.language
@@ -304,6 +306,8 @@ module.exports = class
               queryString: opts.queryString
               queryType: opts.queryType
               isQueryEncoded: opts.queryEncoded or false
+              filterVariantsByAttributes: opts.filterVariantsByAttributes
+              filterPrices: opts.filterPrices
           options.client.host = program.sphereHost if program.sphereHost
           options.client.protocol = program.sphereProtocol if program.sphereProtocol
           if program.sphereAuthHost

--- a/src/spec/export.spec.coffee
+++ b/src/spec/export.spec.coffee
@@ -23,6 +23,24 @@ describe 'Export', ->
 
   describe 'Function to filter variants by attributes', ->
 
+    it 'should keep all variants if no filter for price is given', ->
+
+      # init variant without price
+      variant = variantFactory()
+      variant.prices = []
+      # filter for US prices -> no price should be left in variant
+      filteredVariants = @exporter._filterVariantsByAttributes(
+        [ variant ],
+        []
+      )
+
+      console.log filteredVariants
+
+      actual = filteredVariants[0]
+      expected = variant
+
+      expect(actual).toEqual(expected)
+
     it 'should keep variants that meet the filter condition', ->
 
       variant = variantFactory()

--- a/src/spec/export.spec.coffee
+++ b/src/spec/export.spec.coffee
@@ -1,0 +1,78 @@
+{ Export } = require '../lib/main'
+Config = require '../config'
+
+priceFactory = ({ country } = {}) ->
+  country: country or 'US'
+
+variantFactory = ({ country, published } = {}) ->
+  prices: [
+    priceFactory({ country })
+  ],
+  attributes: [
+    {
+      name: 'published',
+      value: published or true
+    }
+  ]
+
+describe 'Export', ->
+
+  beforeEach ->
+    @exporter = new Export({ client: Config })
+
+  describe 'Function to filter variants by attributes', ->
+
+    it 'should keep variants that meet the filter condition', ->
+
+      variant = variantFactory()
+      filteredVariants = @exporter._filterVariantsByAttributes(
+        [variant],
+        [{ name: 'published', value: true }]
+      )
+
+      actual = filteredVariants[0]
+      expected = variant
+
+      expect(actual).toEqual(expected)
+
+    it 'should remove variants that don\'t meet the filter condition', ->
+
+      variant = variantFactory()
+      filteredVariants = @exporter._filterVariantsByAttributes(
+        [variant],
+        [{ name: 'published', value: false }]
+      )
+
+      actual = filteredVariants[0]
+      expected = undefined
+
+      expect(actual).toEqual(expected)
+
+  describe 'Function to filter prices', ->
+
+    it 'should keep prices that meet the filter condition', ->
+
+      price = priceFactory()
+      filteredVariants = @exporter._filterPrices(
+        [ price ],
+        [{ name: 'country', value: 'US' }]
+      )
+
+      actual = filteredVariants[0]
+      expected = price
+
+      expect(actual).toEqual(expected)
+
+    it 'should remove prices that don\'t meet the filter condition', ->
+
+      price = priceFactory({ country: 'DE' })
+      usPrice = priceFactory({ country: 'US' })
+      filteredPrices = @exporter._filterPrices(
+        [ price, usPrice, usPrice, usPrice ],
+        [{ name: 'country', value: 'DE' }]
+      )
+
+      actual = filteredPrices.length
+      expected = 1
+
+      expect(actual).toEqual(expected)

--- a/src/spec/export.spec.coffee
+++ b/src/spec/export.spec.coffee
@@ -1,5 +1,6 @@
 { Export } = require '../lib/main'
 Config = require '../config'
+_ = require 'underscore'
 
 priceFactory = ({ country } = {}) ->
   country: country or 'US'
@@ -41,6 +42,41 @@ describe 'Export', ->
       filteredVariants = @exporter._filterVariantsByAttributes(
         [variant],
         [{ name: 'published', value: false }]
+      )
+
+      actual = filteredVariants[0]
+      expected = undefined
+
+      expect(actual).toEqual(expected)
+
+    it 'should filter prices if no variant filter is provided', ->
+
+      # init variant with DE price
+      variant = variantFactory({country: 'DE'})
+      variant.prices.push(priceFactory({ country: 'US' }))
+      # filter for US prices -> no price should be left in variant
+      @exporter.queryOptions.filterPrices = [{ name: 'country', value: 'US' }]
+      filteredVariants = @exporter._filterVariantsByAttributes(
+        [ variant ],
+        []
+      )
+
+      actual = filteredVariants[0]
+      expected = _.extend(variant, { prices: [] })
+
+      expect(actual).toEqual(expected)
+
+    it 'should filter out a variant
+    if the price filter filtered out all prices of the variant', ->
+
+      # init variant with DE price
+      variant = variantFactory({country: 'US'})
+      variant.prices.push(priceFactory({ country: 'US' }))
+      # filter for US prices -> no price should be left in variant
+      @exporter.queryOptions.filterPrices = [{ name: 'country', value: 'DE' }]
+      filteredVariants = @exporter._filterVariantsByAttributes(
+        [ variant ],
+        []
       )
 
       actual = filteredVariants[0]


### PR DESCRIPTION
@emmenko @hajoeichler @mmoelli
This is not the most beautiful solution, but it works for the moment.
We can now filter variants by attributes and we can filter the variants prices.
If a variant has no prices left, after the price filter was applied to it, it gets removed from the export. This gives use the possibility to export for certain countries only.
What do you think about this approach?