### PR TITLE
Import multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This means that the CSV may contain only those columns that contain changed valu
 
     -h, --help                                 output usage information
     -c, --csv <file>                           CSV file containing products to import
+    -z, --zip <file>                           ZIP archive containing multiple product files to import
     -l, --language [lang]                      Default language to using during import (for slug generation, category linking etc. - default is en)
     --csvDelimiter [delim]                     CSV Delimiter that separates the cells (default is comma - ",")
     --multiValueDelimiter [delim]              Delimiter to separate values inside of a cell (default is semicolon - ";")

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "tmp": "0.0.28",
     "underscore": "1.8.3",
     "underscore-mixins": "*",
-    "underscore.string": "2.4.x"
+    "underscore.string": "2.4.x",
+    "walk-sync": "^0.3.1"
   },
   "devDependencies": {
     "coffeelint": "^1.14.2",

--- a/src/spec/integration/import.spec.coffee
+++ b/src/spec/integration/import.spec.coffee
@@ -1,9 +1,16 @@
+Promise = require 'bluebird'
 _ = require 'underscore'
+archiver = require 'archiver'
 _.mixin require('underscore-mixins')
 {Import} = require '../../lib/main'
 Config = require '../../config'
 TestHelpers = require './testhelpers'
 cuid = require 'cuid'
+path = require 'path'
+tmp = require 'tmp'
+fs = Promise.promisifyAll require('fs')
+# will clean temporary files even when an uncaught exception occurs
+tmp.setGracefulCleanup()
 
 TEXT_ATTRIBUTE_NONE = 'attr-text-n'
 LTEXT_ATTRIBUTE_COMBINATION_UNIQUE = 'attr-ltext-cu'
@@ -811,3 +818,56 @@ describe 'Import integration test', ->
         expect(p.variants[0].prices[0].value).toEqual { centAmount: 80000, currencyCode: 'USD' }
         done()
       .catch (err) -> done _.prettify(err)
+
+
+    it 'should import multiple archived products', (done) ->
+      tempDir = tmp.dirSync({ unsafeCleanup: true })
+      archivePath = path.join tempDir.name, 'products.zip'
+
+      csv = [
+        """
+          productType,name,variantId,slug
+          #{@productType.id},#{@newProductName},1,#{@newProductSlug}
+          """,
+        """
+          productType,name,variantId,slug
+          #{@productType.id},#{@newProductName+1},1,#{@newProductSlug+1}
+          """
+      ]
+
+      Promise.map csv, (content, index) ->
+        fs.writeFileAsync path.join(tempDir.name, "products-#{index}.csv"), content
+      .then ->
+        archive = archiver 'zip'
+        outputStream = fs.createWriteStream archivePath
+
+        new Promise (resolve, reject) ->
+          outputStream.on 'close', () -> resolve()
+          archive.on 'error', (err) -> reject(err)
+          archive.pipe outputStream
+
+          archive.bulk([
+            { expand: true, cwd: tempDir.name, src: ['**'], dest: 'products'}
+          ])
+          archive.finalize()
+      .then =>
+        @importer.importArchive(archivePath)
+      .then =>
+        @client.productProjections.staged(true)
+          .sort("createdAt", "ASC")
+          .where("productType(id=\"#{@productType.id}\")").fetch()
+      .then (result) =>
+        expect(_.size result.body.results).toBe 2
+
+        p = result.body.results[0]
+        expect(p.name).toEqual en: @newProductName
+        expect(p.slug).toEqual en: @newProductSlug
+
+        p = result.body.results[1]
+        expect(p.name).toEqual en: @newProductName+1
+        expect(p.slug).toEqual en: @newProductSlug+1
+
+        done()
+      .catch (err) -> done _.prettify(err)
+      .finally ->
+        tempDir.removeCallback()


### PR DESCRIPTION
Add possibility to import archived product files.

For example, from full export we get an archive with products saved in different files based on their product type. With this feature, we can take this archive and import it back to sphere.