### PR TITLE
fix(export): Remove duplicate header entries when doing full export

### DIFF
--- a/src/coffee/export.coffee
+++ b/src/coffee/export.coffee
@@ -177,6 +177,21 @@ class Export
       ])
       archive.finalize()
 
+  # function will remove duplicate header entries
+  # it is not possible to create a custom product attribute named as categories/images/taxCategories/ etc..
+  # so this is intended only for old projects and should be removed in the future
+  _removeDuplicities: (list) ->
+    uniqueList = _.unique(list)
+
+    if uniqueList.length != list.length
+      list = list.sort()
+      list = list.filter (v,i,o) ->
+        if i > 0 && v == o[i-1]
+          return v
+
+      console.warn "WARN: Removing duplicate header entries: #{list.join(",")}"
+    return uniqueList
+
   exportFull: (output, staged = true) =>
     lang = GLOBALS.DEFAULT_LANGUAGE
     console.log 'Creating full export for "%s" language', lang
@@ -192,6 +207,8 @@ class Export
       Promise.map productTypes.body.results, (type) =>
         console.log 'Processing products with productType "%s"', type.name
         csv = new ExportMapping().createTemplate(type, [lang])
+        csv = @_removeDuplicities csv
+
         fileName = _.slugify(type.name)+"_"+type.id+"."+@options.exportFormat
         filePath = path.join(tempDir.name, fileName)
         condition = 'productType(id="'+type.id+'")'

--- a/src/coffee/export.coffee
+++ b/src/coffee/export.coffee
@@ -184,8 +184,7 @@ class Export
     uniqueList = _.unique(list)
 
     if uniqueList.length != list.length
-      list = list.sort()
-      list = list.filter (v,i,o) ->
+      list = list.sort().filter (v,i,o) ->
         if i > 0 && v == o[i-1]
           return v
 

--- a/src/spec/fullExport.spec.coffee
+++ b/src/spec/fullExport.spec.coffee
@@ -1,0 +1,37 @@
+{ Export } = require '../lib/main'
+Config = require '../config'
+_ = require 'underscore'
+
+describe 'Export', ->
+
+  beforeEach ->
+    @exporter = new Export({ client: Config })
+
+  describe 'Function to filter out duplicate header entries', ->
+
+    it 'should remove duplicate header entries', ->
+      header = [
+        'booleans',
+        'categories',
+        'channels',
+        'customObjects',
+        'numbers',
+        'prices',
+        'productType',
+        'channels',
+        'productTypes',
+        'categories',
+        'variantId' ]
+
+      headerFiltered = [
+        'booleans',
+        'categories',
+        'channels',
+        'customObjects',
+        'numbers',
+        'prices',
+        'productType',
+        'productTypes',
+        'variantId' ]
+
+      expect(@exporter._removeDuplicities(header)).toEqual headerFiltered


### PR DESCRIPTION
Some old projects may have custom attributes named as common ones (images, categories, taxCategories, ...etc). This code will go through generated header and remove duplicate entries.

Fix for issue https://github.com/sphereio/sphere-node-product-csv-sync/issues/143