### PR TITLE
CategoryOrderHints using externalId instead of category.id

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,8 @@ productType,name.en,variantId
     -l, --language [lang]         Language used on export for localised attributes (except lenums) and category names (default is en)
     --queryEncoded                Whether the given query string is already encoded or not
     --fillAllRows                 When given product attributes like name will be added to each variant row.
-    --categoryBy                  Define which identifier should be used to for the categories column - either slug or externalId. If nothing given the named path is used.
+    --categoryBy                  Define which identifier should be used for the categories column - either slug or externalId. If nothing given the named path is used.
+    --categoryOrderHintBy         Define which identifier should be used for the categoryOrderHints column - either id or externalId. If nothing given the category id is used.
     --filterVariantsByAttributes  Query string to filter variants of products
     --filterPrices  Query string to filter prices of variants
     --templateDelimiter <delimiter> Delimiter used in template | default: ,

--- a/README.md
+++ b/README.md
@@ -94,20 +94,21 @@ This means that the CSV may contain only those columns that contain changed valu
 
   Options:
 
-    -h, --help                                 output usage information
-    -c, --csv <file>                           CSV file containing products to import
-    -z, --zip <file>                           ZIP archive containing multiple product files to import
-    -l, --language [lang]                      Default language to using during import (for slug generation, category linking etc. - default is en)
-    --csvDelimiter [delim]                     CSV Delimiter that separates the cells (default is comma - ",")
-    --multiValueDelimiter [delim]              Delimiter to separate values inside of a cell (default is semicolon - ";")
-    --customAttributesForCreationOnly <items>  List of comma-separated attributes to use when creating products (ignore when updating)
-    --continueOnProblems                       When a product does not validate on the server side (400er response), ignore it and continue with the next products
+    -h, --help                                 Output usage information.
+    -c, --csv <file>                           CSV file containing products to import.
+    -z, --zip <file>                           ZIP archive containing multiple product files to import.
+    -l, --language [lang]                      Default language to using during import (for slug generation, category linking etc. - default is en).
+    --csvDelimiter [delim]                     CSV Delimiter that separates the cells (default is comma - ",").
+    --multiValueDelimiter [delim]              Delimiter to separate values inside of a cell (default is semicolon - ";").
+    --customAttributesForCreationOnly <items>  List of comma-separated attributes to use when creating products (ignore when updating).
+    --continueOnProblems                       When a product does not validate on the server side (400er response), ignore it and continue with the next products.
     --suppressMissingHeaderWarning             Do not show which headers are missing per produt type.
     --allowRemovalOfVariants                   If given variants will be removed if there is no corresponding row in the CSV. Otherwise they are not touched.
-    --publish                                  When given, all changes will be published immediately
-    --updatesOnly                              Won't create any new products, only updates existing
-    --dryRun                                   Will list all action that would be triggered, but will not POST them to SPHERE.IO
-    -m, --matchBy [value]                      Product attribute name which will be used to match products. Possible values: id, slug, sku, <custom_attribute_name>. Default: id. Localized attribute types are not supported for <custom_attribute_name> option
+    --mergeCategoryOrderHints                  Merge category order hints instead of replacing them with value readed from an import file.
+    --publish                                  When given, all changes will be published immediately.
+    --updatesOnly                              Won't create any new products, only updates existing.
+    --dryRun                                   Will list all action that would be triggered, but will not POST them to SPHERE.IO.
+    -m, --matchBy [value]                      Product attribute name which will be used to match products. Possible values: id, slug, sku, <custom_attribute_name>. Default: id. Localized attribute types are not supported for <custom_attribute_name> option.
 ```
 
 ### CSV Format

--- a/src/coffee/exportmapping.coffee
+++ b/src/coffee/exportmapping.coffee
@@ -18,6 +18,7 @@ class ExportMapping
     @header = options.header
     @fillAllRows = options.fillAllRows
     @categoryBy = options.categoryBy
+    @categoryOrderHintBy = options.categoryOrderHintBy
 
   mapProduct: (product, productTypes) ->
     productType = productTypes[@typesService.id2index[product.productType.id]]
@@ -106,7 +107,10 @@ class ExportMapping
       if product.categoryOrderHints?
         categoryIds = Object.keys product.categoryOrderHints
         categoryOrderHints = _.map categoryIds, (categoryId) =>
-          return "#{@categoryService.id2externalId[categoryId]}:#{product.categoryOrderHints[categoryId]}"
+          categoryIdentificator = categoryId
+          if @categoryOrderHintBy == 'externalId'
+            categoryIdentificator = @categoryService.id2externalId[categoryId]
+          return "#{categoryIdentificator}:#{product.categoryOrderHints[categoryId]}"
         row[@header.toIndex CONS.HEADER_CATEGORY_ORDER_HINTS] = categoryOrderHints.join GLOBALS.DELIM_MULTI_VALUE
       else
         row[@header.toIndex CONS.HEADER_CATEGORY_ORDER_HINTS] = ''

--- a/src/coffee/exportmapping.coffee
+++ b/src/coffee/exportmapping.coffee
@@ -103,10 +103,13 @@ class ExportMapping
             row[index] = product[attribName][lang]
 
     if @header.has(CONS.HEADER_CATEGORY_ORDER_HINTS)
-      categoryIds = Object.keys product.categoryOrderHints
-      categoryOrderHints = _.map categoryIds, (categoryId) ->
-        return "#{categoryId}:#{product.categoryOrderHints[categoryId]}"
-      row[@header.toIndex CONS.HEADER_CATEGORY_ORDER_HINTS] = categoryOrderHints.join GLOBALS.DELIM_MULTI_VALUE
+      if product.categoryOrderHints?
+        categoryIds = Object.keys product.categoryOrderHints
+        categoryOrderHints = _.map categoryIds, (categoryId) =>
+          return "#{@categoryService.id2externalId[categoryId]}:#{product.categoryOrderHints[categoryId]}"
+        row[@header.toIndex CONS.HEADER_CATEGORY_ORDER_HINTS] = categoryOrderHints.join GLOBALS.DELIM_MULTI_VALUE
+      else
+        row[@header.toIndex CONS.HEADER_CATEGORY_ORDER_HINTS] = ''
 
     row
 

--- a/src/coffee/import.coffee
+++ b/src/coffee/import.coffee
@@ -43,10 +43,12 @@ class Import
     options.importFormat = options.importFormat || "csv"
     options.csvDelimiter = options.csvDelimiter || ","
     options.encoding = options.encoding || "utf-8"
+    options.mergeCategoryOrderHints = !!options.mergeCategoryOrderHints
     @dryRun = false
     @updatesOnly = false
     @publishProducts = false
     @continueOnProblems = options.continueOnProblems
+    @mergeCategoryOrderHints = options.mergeCategoryOrderHints
     @allowRemovalOfVariants = false
     @blackListedCustomAttributesForUpdate = []
     @customAttributeNameToMatch = undefined
@@ -315,6 +317,12 @@ class Import
       else
         @create(entry.product, entry.rowIndex)
 
+  _mergeCategoryOrderHints: (existingProduct, product) ->
+    if @mergeCategoryOrderHints
+      deepMerge product.categoryOrderHints, existingProduct.categoryOrderHints
+    else
+      product.categoryOrderHints
+
   _isBlackListedForUpdate: (attributeName) ->
     if _.isEmpty @blackListedCustomAttributesForUpdate
       false
@@ -322,6 +330,7 @@ class Import
       _.contains @blackListedCustomAttributesForUpdate, attributeName
 
   update: (product, existingProduct, id2SameForAllAttributes, header, rowIndex) ->
+    product.categoryOrderHints = @_mergeCategoryOrderHints existingProduct, product
     allSameValueAttributes = id2SameForAllAttributes[product.productType.id]
     config = [
       { type: 'base', group: 'white' }

--- a/src/coffee/import.coffee
+++ b/src/coffee/import.coffee
@@ -43,7 +43,7 @@ class Import
     options.importFormat = options.importFormat || "csv"
     options.csvDelimiter = options.csvDelimiter || ","
     options.encoding = options.encoding || "utf-8"
-    options.mergeCategoryOrderHints = !!options.mergeCategoryOrderHints
+    options.mergeCategoryOrderHints = Boolean(options.mergeCategoryOrderHints)
     @dryRun = false
     @updatesOnly = false
     @publishProducts = false

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -115,6 +115,7 @@ module.exports = class
       .option '--continueOnProblems', 'When a product does not validate on the server side (400er response), ignore it and continue with the next products'
       .option '--suppressMissingHeaderWarning', 'Do not show which headers are missing per produt type.'
       .option '--allowRemovalOfVariants', 'If given variants will be removed if there is no corresponding row in the CSV. Otherwise they are not touched.'
+      .option '--mergeCategoryOrderHints', 'Merge category order hints instead of replacing them'
       .option '--publish', 'When given, all changes will be published immediately'
       .option '--updatesOnly', "Won't create any new products, only updates existing"
       .option '--dryRun', 'Will list all action that would be triggered, but will not POST them to SPHERE.IO'
@@ -137,6 +138,7 @@ module.exports = class
             encoding: opts.encoding
             importFormat: if opts.xlsx then 'xlsx' else 'csv'
             debug: !!opts.parent.debug
+            mergeCategoryOrderHints: !!opts.mergeCategoryOrderHints
 
           options.host = program.sphereHost if program.sphereHost
           options.protocol = program.sphereProtocol if program.sphereProtocol

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -283,7 +283,8 @@ module.exports = class
       .option '-l, --language [lang]', 'Language used on export for localised attributes (except lenums) and category names (default is en)'
       .option '--queryEncoded', 'Whether the given query string is already encoded or not', false
       .option '--fillAllRows', 'When given product attributes like name will be added to each variant row.'
-      .option '--categoryBy <name>', 'Define which identifier should be used to for the categories column - either slug or externalId. If nothing given the named path is used.'
+      .option '--categoryBy <name>', 'Define which identifier should be used for the categories column - either slug or externalId. If nothing given the named path is used.'
+      .option '--categoryOrderHintBy <name>', 'Define which identifier should be used for the categoryOrderHints column - either id or externalId. If nothing given the category id is used.', 'id'
       .option '--filterVariantsByAttributes <query>', 'Query string to filter variants of products'
       .option '--filterPrices <query>', 'Query string to filter prices of products'
       .option '--templateDelimiter <delimiter>', 'Delimiter used in template | default: ,', ","
@@ -305,6 +306,7 @@ module.exports = class
             templateDelimiter: opts.templateDelimiter
             fillAllRows: opts.fillAllRows
             categoryBy: opts.categoryBy
+            categoryOrderHintBy: opts.categoryOrderHintBy || 'id'
             debug: !!opts.parent.debug
             client: _.extend credentials,
               timeout: program.timeout

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -137,8 +137,8 @@ module.exports = class
             csvDelimiter: opts.csvDelimiter
             encoding: opts.encoding
             importFormat: if opts.xlsx then 'xlsx' else 'csv'
-            debug: !!opts.parent.debug
-            mergeCategoryOrderHints: !!opts.mergeCategoryOrderHints
+            debug: Boolean(opts.parent.debug)
+            mergeCategoryOrderHints: Boolean(opts.mergeCategoryOrderHints)
 
           options.host = program.sphereHost if program.sphereHost
           options.protocol = program.sphereProtocol if program.sphereProtocol
@@ -307,7 +307,7 @@ module.exports = class
             fillAllRows: opts.fillAllRows
             categoryBy: opts.categoryBy
             categoryOrderHintBy: opts.categoryOrderHintBy || 'id'
-            debug: !!opts.parent.debug
+            debug: Boolean(opts.parent.debug)
             client: _.extend credentials,
               timeout: program.timeout
               user_agent: "#{package_json.name} - Export - #{package_json.version}"

--- a/src/spec/exportmapping.spec.coffee
+++ b/src/spec/exportmapping.spec.coffee
@@ -226,6 +226,101 @@ describe 'ExportMapping', ->
       row = @exportMapping._mapBaseProduct(product, type)
       expect(row).toEqual [ 'myType', '123', 'BRI;9997']
 
+    it 'should not map categoryOrderhints when they are not present', ->
+      @exportMapping.categoryService = new Categories()
+      @exportMapping.categoryService.buildMaps [
+        {
+          id: '9e6de6ad-cc94-4034-aa9f-276ccb437efd',
+          name:
+            en: 'BrilliantCoeur',
+          slug:
+            en: 'brilliantcoeur',
+          externalId: 'BRI',
+        },
+        {
+          id: '0afacd76-30d8-431e-aff9-376cd1b4c9e6',
+          name:
+            en: 'Autumn / Winter 2016',
+          slug:
+            en: 'autmn-winter-2016',
+          externalId: '9997',
+        }
+      ]
+
+      @exportMapping.categoryBy = 'externalId'
+      @exportMapping.header = new Header(
+        [CONS.HEADER_PRODUCT_TYPE,
+          CONS.HEADER_ID,
+          CONS.HEADER_CATEGORY_ORDER_HINTS])
+      @exportMapping.header.toIndex()
+
+      product =
+        id: '123'
+        categories: [
+          {
+            typeId: 'category',
+            id: '9e6de6ad-cc94-4034-aa9f-276ccb437efd'
+          },
+          {
+            typeId: 'category',
+            id: '0afacd76-30d8-431e-aff9-376cd1b4c9e6'
+          }
+        ],
+        masterVariant:
+          attributes: []
+
+      type =
+        name: 'myType'
+        id: 'typeId123'
+      row = @exportMapping._mapBaseProduct(product, type)
+
+      expect(row).toEqual [ 'myType', '123', '']
+
+    it 'should map productType (name), product id and categoryOrderhints by externalId', ->
+      @exportMapping.categoryService = new Categories()
+      @exportMapping.categoryService.buildMaps [
+        {
+          id: '9e6de6ad-cc94-4034-aa9f-276ccb437efd',
+          name:
+            en: 'BrilliantCoeur',
+          slug:
+            en: 'brilliantcoeur',
+          externalId: 'BRI',
+        },
+        {
+          id: '0afacd76-30d8-431e-aff9-376cd1b4c9e6',
+          name:
+            en: 'Autumn / Winter 2016',
+          slug:
+            en: 'autmn-winter-2016',
+          externalId: '9997',
+        }
+      ]
+
+      @exportMapping.categoryBy = 'externalId'
+      @exportMapping.header = new Header(
+        [CONS.HEADER_PRODUCT_TYPE,
+          CONS.HEADER_ID,
+          CONS.HEADER_CATEGORY_ORDER_HINTS])
+      @exportMapping.header.toIndex()
+
+      product =
+        id: '123'
+        categoryOrderHints: {
+          '9e6de6ad-cc94-4034-aa9f-276ccb437efd': '0.9283'
+          '0afacd76-30d8-431e-aff9-376cd1b4c9e6': '0.3223'
+        },
+        categories: [],
+        masterVariant:
+          attributes: []
+
+      type =
+        name: 'myType'
+        id: 'typeId123'
+      row = @exportMapping._mapBaseProduct(product, type)
+
+      expect(row).toEqual [ 'myType', '123', 'BRI:0.9283;9997:0.3223']
+
     it 'should map createdAt and lastModifiedAt', ->
       @exportMapping.header = new Header(
         [CONS.HEADER_CREATED_AT,

--- a/src/spec/exportmapping.spec.coffee
+++ b/src/spec/exportmapping.spec.coffee
@@ -319,7 +319,7 @@ describe 'ExportMapping', ->
         id: 'typeId123'
       row = @exportMapping._mapBaseProduct(product, type)
 
-      expect(row).toEqual [ 'myType', '123', 'BRI:0.9283;9997:0.3223']
+      expect(row).toEqual [ 'myType', '123', '9e6de6ad-cc94-4034-aa9f-276ccb437efd:0.9283;0afacd76-30d8-431e-aff9-376cd1b4c9e6:0.3223']
 
     it 'should map createdAt and lastModifiedAt', ->
       @exportMapping.header = new Header(

--- a/src/spec/integration/categoryOrderHint.spec.coffee
+++ b/src/spec/integration/categoryOrderHint.spec.coffee
@@ -209,7 +209,7 @@ describe 'categoryOrderHints', ->
         csv =
           """
           productType,id,version,slug,categoryOrderHints
-          #{@productType.id},#{@product.id},#{@product.version},#{@product.slug},#{@category.id}: 0.9
+          #{@productType.id},#{@product.id},#{@product.version},#{@product.slug},#{@category.externalId}: 0.9
           """
         im = createImporter(
           continueOnProblems: true
@@ -246,7 +246,7 @@ describe 'categoryOrderHints', ->
         expectedCSV =
           """
           productType,id,variantId,categoryOrderHints
-          #{@productType.name},#{@product.id},#{@product.lastVariantId},#{@category.id}:0.5
+          #{@productType.name},#{@product.id},#{@product.lastVariantId},#{@category.externalId}:0.5
 
           """
         @export.exportDefault(template, file)

--- a/src/spec/mapping.spec.coffee
+++ b/src/spec/mapping.spec.coffee
@@ -780,3 +780,19 @@ describe 'Mapping', ->
         expect(data.product).toEqual @expectedProduct
         done()
       .catch done
+
+    it 'should should map the categoryOrderHints using a category externalId', (done) ->
+      csv =
+        """
+        productType,name,variantId,sku,categoryOrderHints
+        foo,myProduct,1,x,#{@exampleCategory.externalId}:0.9
+        """
+      @validator.parse csv
+      .then (parsed) =>
+        @map.header = parsed.header
+        @validator.validateOffline parsed.data
+        data = @map.mapProduct @validator.rawProducts[0], @productType
+
+        expect(data.product).toEqual @expectedProduct
+        done()
+      .catch done


### PR DESCRIPTION
This PR adds two new parameters
- `--categoryOrderHintBy ` will let us export categoryOrderHints with category extrenalId instead of category id as requested here #154 
- `--mergeCategoryOrderHints` will merge old and new categoryOrderHints instead of replacing them with new values.