### PR TITLE
fix(import): match masterVariant by id or sku

### DIFF
--- a/src/coffee/import.coffee
+++ b/src/coffee/import.coffee
@@ -246,7 +246,12 @@ class Import
 
         variantInfo = sku2variantInfo[variant.sku]
         variant.id = variantInfo.id
-        if variant.id is 1
+
+        # If the variantId is 1, masterVariant will be matched
+        # Otherwise it tries to match with the SKU
+        # This means if the masterVariant has no SKU and the id is not 1, the
+        # masterVariant will not be updated
+        if variant.id is 1 or variant.sku is existingProduct.masterVariant.sku
           existingProduct.masterVariant = variant
         else
           existingProduct.variants[variantInfo.index] = variant

--- a/src/spec/import.spec.coffee
+++ b/src/spec/import.spec.coffee
@@ -67,7 +67,7 @@ describe 'Import', ->
       @header = {}
     it 'should map masterVariant', ->
       existingProducts = [
-        { masterVariant: { id: 1, sku: "mySKU" }, variants: [] }
+        { masterVariant: { id: 2, sku: "mySKU" }, variants: [] }
       ]
       #@importer.initMatcher existingProducts
       entry =
@@ -77,7 +77,7 @@ describe 'Import', ->
       expect(_.size productsToUpdate).toBe 1
       product = productsToUpdate[0].product
       expect(product.masterVariant).toBeDefined()
-      expect(product.masterVariant.id).toBe 1
+      expect(product.masterVariant.id).toBe 2
       expect(product.masterVariant.sku).toBe 'mySKU'
       expect(_.size product.variants).toBe 0
       expect(product.masterVariant.attributes).toEqual [{ foo: 'bar' }]


### PR DESCRIPTION
#### Summary
<!-- Provide a short summary of your changes -->
Fixes issue where `masterVariant` was not updated if it has an `id` other that 1

#### Note
<!-- Describe the changes in this PR here and provide some context -->
If the variantId is 1, masterVariant will be matched, otherwise it tries to match with the SKU. This means if the masterVariant has no `SKU` (which is optional) and the masterVariant id is not 1, the masterVariant will not be updated

Resolves #189 