### PR TITLE
191 auto split update actions if more than 500

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "archiver": "^1.1.0",
-    "bluebird": "2.9.x",
+    "bluebird": "^3.5.1",
     "commander": "2.3.0",
     "csv": "0.3.7",
     "exceljs": "^0.2.28",

--- a/src/coffee/import.coffee
+++ b/src/coffee/import.coffee
@@ -421,8 +421,8 @@ class Import
       if allUpdateRequests.actions.length
         chunkifiedUpdateRequests = @splitUpdateActionsArray(allUpdateRequests, 500)
         Promise.mapSeries(chunkifiedUpdateRequests, (updateRequest) => @client.products.byId(filtered.getUpdateId()).update(updateRequest))
-        .then (result) =>
-          @publishProduct(result[0].body, rowIndex)
+        .then ([result]) =>
+          @publishProduct(result.body, rowIndex)
           .then -> Promise.resolve "[row #{rowIndex}] Product updated."
         .catch (err) =>
           msg = "[row #{rowIndex}] Problem on updating product:\n#{_.prettify err}\n#{_.prettify err.body}"

--- a/src/spec/import.spec.coffee
+++ b/src/spec/import.spec.coffee
@@ -109,3 +109,25 @@ describe 'Import', ->
       expect(product.variants[0].attributes).toEqual [ { foo: 'bar2' } ]
       expect(product.variants[1].id).toBe 4
       expect(product.variants[1].attributes).toEqual [ { foo: 'bar4' } ]
+
+  describe 'splitUpdateActionsArray', ->
+    it 'should split an array when exceeding max amount of allowed actions', ->
+      updateRequest = {
+        actions: [
+          { action: 'updateAction1', payload: 'bar1' },
+          { action: 'updateAction2', payload: 'bar2' },
+          { action: 'updateAction3', payload: 'bar3' },
+          { action: 'updateAction4', payload: 'bar4' },
+          { action: 'updateAction5', payload: 'bar5' },
+          { action: 'updateAction6', payload: 'bar6' },
+          { action: 'updateAction7', payload: 'bar7' },
+          { action: 'updateAction8', payload: 'bar8' },
+          { action: 'updateAction9', payload: 'bar9' },
+          { action: 'updateAction10', payload: 'bar10' }
+        ],
+        version: 1
+      }
+      # max amount of actions = 3
+      splitArray = @importer.splitUpdateActionsArray(updateRequest, 3)
+      # array of 10 actions divided by max of 3 becomes 4 arrays
+      expect(splitArray.length).toEqual 4

--- a/src/spec/integration/import.spec.coffee
+++ b/src/spec/integration/import.spec.coffee
@@ -1232,7 +1232,7 @@ describe 'Import integration test', ->
         im.import(csv)
       .then (result) =>
         expect(_.size result).toBe 1
-        expect(result[0][0]).toBe '[row 2] Product updated.'
+        expect(result[0]).toBe '[row 2] Product updated.'
         @client.productProjections.staged(true).where("productType(id=\"#{@productType.id}\")").fetch()
       .then (result) =>
         expect(_.size result.body.results).toBe 1

--- a/src/spec/integration/import.spec.coffee
+++ b/src/spec/integration/import.spec.coffee
@@ -1197,3 +1197,51 @@ describe 'Import integration test', ->
         # no concurrentModification found
         done()
       .catch (err) -> done _.prettify(err)
+
+    it 'should split actions if there are more than 500 in actions array', (done) ->
+      numberOfVariants = 501
+      
+      csvCreator = (productType, newProductName, newProductSlug, rows) ->
+        changes = ""
+        i = 0
+        while i < rows
+          changes += "#{productType.id},#{newProductName},#{1+i},#{newProductSlug},#{'productKey'+i},#{'variantKey'+i}\n"
+          i++
+        csv =
+        """
+        #{changes}
+        """
+        csv
+
+      csv =
+        """
+        productType,name,variantId,slug,key,variantKey
+        #{@productType.id},#{@newProductName},1,#{@newProductSlug},productKey0,variantKey0"
+        """
+      @importer.import(csv)
+      .then (result) =>
+        expect(_.size result).toBe 1
+        expect(result[0]).toBe '[row 2] New product created.'
+        csv =
+          """
+          productType,name,variantId,slug,key,variantKey
+          #{csvCreator(@productType, @newProductName, @newProductSlug, numberOfVariants)}
+          """
+        im = createImporter()
+        im.matchBy = 'slug'
+        im.import(csv)
+      .then (result) =>
+        expect(_.size result).toBe 1
+        expect(result[0][0]).toBe '[row 2] Product updated.'
+        @client.productProjections.staged(true).where("productType(id=\"#{@productType.id}\")").fetch()
+      .then (result) =>
+        expect(_.size result.body.results).toBe 1
+        p = result.body.results[0]
+        expect(p.name).toEqual en: "#{@newProductName}"
+        expect(p.slug).toEqual en: @newProductSlug
+        expect(p.key).toEqual 'productKey0'
+        expect(p.masterVariant.key).toEqual 'variantKey0'
+        expect(p.variants.length).toBe numberOfVariants-1
+
+        done()
+      .catch (err) -> done _.prettify(err)


### PR DESCRIPTION
#### Summary
Fix bug where update actions array would not be split if it was above the maximum allowed 500

#### Description
PR splits the update actions into chunks of 500 actions and puts them into an array of calls. Then uses promise.all to process the array.

#### Todo

- Tests
    - [x] Unit
    - [x] Integration

resolves #191
