### PR TITLE
Issue 208 fix publishing after update

### DIFF
--- a/src/coffee/import.coffee
+++ b/src/coffee/import.coffee
@@ -209,7 +209,7 @@ class Import
       Promise.resolve result
 
   isConcurrentModification: (err) ->
-    err.body.statusCode == 409
+    err.body?.statusCode == 409
 
   processProductsBasesOnSkus: (products) ->
     filterInput = QueryUtils.mapMatchFunction("sku")(products)


### PR DESCRIPTION
#### Summary
When updating a product, we should send update requests in series, set a proper version to update request and return the last product's version to the next processing (eg. to `publishProduct` method)
Fixes #208
#### Todo

- Tests
    - [ ] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
