### PR TITLE
fix(sphere-node-product-csv-sync): Change misleading error message

### DIFF
--- a/src/coffee/mapping.coffee
+++ b/src/coffee/mapping.coffee
@@ -78,7 +78,7 @@ class Mapping
 
   ensureValidSlug: (slug, rowIndex, appendix = '') ->
     unless _.isString(slug) and slug.length > 2
-      @errors.push "[row #{rowIndex}:#{CONS.HEADER_SLUG}] Can't generate valid slug out of '#{slug}'!"
+      @errors.push "[row #{rowIndex}:#{CONS.HEADER_SLUG}] Can't generate valid slug out of '#{slug}'! If you did not provide slug in your file, please do so as slug could not be auto-generated from the product name given."
       return
     @slugs or= []
     currentSlug = "#{slug}#{appendix}"


### PR DESCRIPTION
### Summary
Change misleading error message

#### Description
Import of CSV file  in which the name.en is just a '.' in sphere-node-product-csv-sync, misleading error message was shown and the root cause of the error was not shown.

Closes #210 