### PR TITLE
fix(export): add missing customWherePredicate

### DIFF
--- a/src/coffee/export.coffee
+++ b/src/coffee/export.coffee
@@ -160,7 +160,7 @@ class Export
       uri: productsService.build()
       method: 'GET'
     else
-      productsService.where(customWherePredicate || '')
+      productsService.where(customWherePredicate) if customWherePredicate
 
       uri: productsService.build()
       method: 'GET'

--- a/src/coffee/export.coffee
+++ b/src/coffee/export.coffee
@@ -59,8 +59,6 @@ class Export
         host: @options.authConfig.host
         projectKey: @projectKey
         credentials: @options.authConfig.credentials
-      createQueueMiddleware
-        concurrency: 10
       createUserAgentMiddleware @options.userAgentConfig
       createHttpMiddleware @options.httpConfig
     ])
@@ -144,9 +142,6 @@ class Export
     query.where = if query.where then query.where + " AND "+predicate else predicate
     query
 
-  _stringifyQueryString: (query) ->
-    decodeURIComponent(queryStringParser.stringify(query))
-
   # return the correct product service in case query string is used or not
   _getProductService: (staged = true, customWherePredicate = false) ->
     productsService = createRequestBuilder({@projectKey})
@@ -162,8 +157,13 @@ class Export
 
       productsService.where(query.where) if query.where
 
-    uri: productsService.build()
-    method: 'GET'
+      uri: productsService.build()
+      method: 'GET'
+    else
+      productsService.where(customWherePredicate || '')
+
+      uri: productsService.build()
+      method: 'GET'
 
   _fetchResources: =>
     data = [


### PR DESCRIPTION
#### Summary
Add missing `customWherePredicate`, remove unnecessary queuing and delete unused `_stringifyQueryString` function.

#### Description
When we migrated to the new JS SDK we forgot to add the `customWherePredicate` as it was used [here](https://github.com/sphereio/sphere-node-product-csv-sync/commit/dd1c91cad6f53d9a47568052b73bbed12f0fc365#diff-6bcf5a5c3fede97b90ad47a12b6beaa4L139) to the new implementation [here](https://github.com/sphereio/sphere-node-product-csv-sync/commit/dd1c91cad6f53d9a47568052b73bbed12f0fc365#diff-6bcf5a5c3fede97b90ad47a12b6beaa4R162).

This caused a bug which made the exporter export a lot more products than clients needed. Especially for big customers this would change the export time from under 20 mins to over 6 hours.

Finally, since we are using the JS SDK's [process method](https://commercetools.github.io/nodejs/sdk/api/sdkClient.html#processrequest-processfn-options) there is no need to use the `createQueueMiddleware` as the method _iterates_ through the requests and does not call them all concurrently. 

resolves #220

#### Todo

- Tests
    - [x] Unit
    - [x] Integration