### PR TITLE
(fix) test and implement a fix for failure to maintain state properly when processing an update without one

### DIFF
--- a/src/coffee/import.coffee
+++ b/src/coffee/import.coffee
@@ -418,8 +418,11 @@ class Import
 
   update: (product, existingProduct, id2SameForAllAttributes, header, rowIndex, publish) ->
     product.categoryOrderHints = @_mergeCategoryOrderHints existingProduct, product
-    if (not product.state? and not existingProduct.state? and @defaultState?)
-      @assignStateFromDefault (product)
+    if (not product.state? and @defaultState?)
+      if (not existingProduct.state?)
+        @assignStateFromDefault (product)
+      else if (existingProduct.state?)
+        product.state = existingProduct.state
     allSameValueAttributes = id2SameForAllAttributes[product.productType.id]
     config = [
       { type: 'base', group: 'white' }


### PR DESCRIPTION
## Summary

Test and implement a fix for failure to maintain state properly when processing an update without one

## Description

This concerns the situation when a default state is provided, i.e. all products must have states, and an update is received for a product the existing version of which has a state, but the version from the CSV file does not.  This situation arises when both the original and update CSV files do not specify state, and the state is assigned during the initial import from the default state.

Before this fix, this resulted in a `transitionState` action being created without specifying what state to transition to, which led to the update being rejected with "Request body does not contain valid JSON."

This work pertains to #125/[PIN-1887](https://jira.rewe-digital.com/browse/PIN-1887).

- Tests
    - [ ] Unit
    - [X] Integration
    - [ ] Acceptance
- [ ] Documentation