### PR TITLE
Add param for exporting only masterVariants #228

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,24 +389,24 @@ productType,name.en,variantId
 
   Options:
 
-    -h, --help                    output usage information
+    -h, --help                    Output usage information
     -t, --template <file>         CSV file containing your header that defines what you want to export
     -o, --out <file>              Path to the file the exporter will write the resulting CSV in
     -x, --xlsx                    Export in XLSX format
     -f, --fullExport              Do a full export. Use --out parameter to specify where to save zip archive with exported files
     -q, --queryString <query>     Query string to specify the sub-set of products to export
-    -l, --language [lang]         Language used on export for localised attributes (except lenums) and category names (default is en)
+    -l, --language [lang]         Language used on export for localised attributes (except lenums) and category names | default: 'en'
     --queryEncoded                Whether the given query string is already encoded or not
     --current                     Will export current product version instead of staged one
     --fillAllRows                 When given product attributes like name will be added to each variant row.
+    --onlyMasterVariants          Export only masterVariants from products | default: false
     --categoryBy                  Define which identifier should be used for the categories column - options 'namedPath'(default), 'slug' and 'externalId'.
     --categoryOrderHintBy         Define which identifier should be used for the categoryOrderHints column - options 'categoryId'(default), 'id' or 'externalId'.
     --filterVariantsByAttributes  Query string to filter variants of products
-    --filterPrices  Query string to filter prices of variants
-    --templateDelimiter <delimiter> Delimiter used in template | default: ,
-    --outputDelimiter <delimiter>   Delimiter used to separate cells in output file | default: ,
-    -e, --encoding [encoding]     Encoding used when saving data to output file | default: utf8
-
+    --filterPrices                Query string to filter prices of variants
+    --templateDelimiter <delimiter> Delimiter used in template | default: ','
+    --outputDelimiter <delimiter>   Delimiter used to separate cells in output file | default: ','
+    -e, --encoding [encoding]     Encoding used when saving data to output file | default: 'utf8'
 ```
 
 #### Full export

--- a/README.md
+++ b/README.md
@@ -425,7 +425,6 @@ You can define the subset of products to export via the `queryString` parameter,
 
 > Please refer to the [API documentation of SPHERE.IO](http://dev.sphere.io/http-api.html#predicates) for further information regarding the predicates.
 
-
 ##### Example
 
 Query first 10 products of a specific product type

--- a/src/coffee/export.coffee
+++ b/src/coffee/export.coffee
@@ -41,6 +41,7 @@ class Export
     @options.templateDelimiter = @options.templateDelimiter || ","
     @options.encoding = @options.encoding || "utf8"
     @options.exportFormat = @options.exportFormat || "csv"
+    @options.onlyMasterVariants = @options.onlyMasterVariants || false
 
     @queryOptions =
       queryString: @options.export?.queryString?.trim()

--- a/src/coffee/exportmapping.coffee
+++ b/src/coffee/exportmapping.coffee
@@ -18,6 +18,7 @@ class ExportMapping
     @taxService = options.taxService
     @header = options.header
     @fillAllRows = options.fillAllRows
+    @onlyMasterVariants = options.onlyMasterVariants || false
     @categoryBy = options.categoryBy
     @categoryOrderHintBy = options.categoryOrderHintBy
 
@@ -28,7 +29,7 @@ class ExportMapping
     if product.masterVariant
       rows.push productRow
 
-    if product.variants
+    if not @onlyMasterVariants and product.variants
       for variant in product.variants
         variantRow = if @fillAllRows
           _.deepClone productRow

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -287,6 +287,7 @@ module.exports = class
       .option '--queryEncoded', 'Whether the given query string is already encoded or not', false
       .option '--current', 'Will export current product version instead of staged one', false
       .option '--fillAllRows', 'When given product attributes like name will be added to each variant row.'
+      .option '--onlyMasterVariants', 'Export only masterVariants from products.', false
       .option '--categoryBy <name>', 'Define which identifier should be used for the categories column - either slug or externalId. If nothing given the named path is used.'
       .option '--categoryOrderHintBy <name>', 'Define which identifier should be used for the categoryOrderHints column - either id or externalId. If nothing given the category id is used.', 'id'
       .option '--filterVariantsByAttributes <query>', 'Query string to filter variants of products'
@@ -309,6 +310,7 @@ module.exports = class
             outputDelimiter: opts.outputDelimiter
             templateDelimiter: opts.templateDelimiter
             fillAllRows: opts.fillAllRows
+            onlyMasterVariants: opts.onlyMasterVariants
             categoryBy: opts.categoryBy
             categoryOrderHintBy: opts.categoryOrderHintBy || 'id'
             debug: Boolean(opts.parent.debug)

--- a/src/spec/exportmapping.spec.coffee
+++ b/src/spec/exportmapping.spec.coffee
@@ -627,3 +627,60 @@ describe 'ExportMapping', ->
       expect(_.contains template, "multilang.de").toBe true
       expect(_.contains template, "multilang.en").toBe true
       expect(_.contains template, "multilang.it").toBe true
+
+  describe '#mapOnlyMasterVariants', ->
+    beforeEach ->
+      @sampleProduct =
+        id: '123'
+        productType:
+          id: 'myType'
+        name:
+          de: 'Hallo'
+        slug:
+          de: 'hallo'
+        description:
+          de: 'Bla bla'
+        masterVariant:
+          id: 1
+          sku: 'var1'
+          key: 'var1Key'
+        variants: [
+          {
+            id: 2
+            sku: 'var2'
+            key: 'var2Key'
+          }
+        ]
+
+    it 'should map all variants', ->
+      _exportMapping = new ExportMapping(
+        typesService:
+          id2index:
+            myType: 0
+      )
+      _exportMapping.header = new Header([CONS.HEADER_VARIANT_ID, CONS.HEADER_SKU])
+      _exportMapping.header.toIndex()
+
+      type =
+        name: 'myType'
+        id: 'typeId123'
+      mappedProduct = _exportMapping.mapProduct @sampleProduct, [type]
+      # both variants should be mapped
+      expect(mappedProduct).toEqual [ [ 1, 'var1' ], [ 2, 'var2' ] ]
+
+    it 'should map only masterVariant', ->
+      _exportMapping = new ExportMapping(
+        onlyMasterVariants: true
+        typesService:
+          id2index:
+            myType: 0
+      )
+      _exportMapping.header = new Header([CONS.HEADER_VARIANT_ID, CONS.HEADER_SKU])
+      _exportMapping.header.toIndex()
+
+      type =
+        name: 'myType'
+        id: 'typeId123'
+      mappedProduct = _exportMapping.mapProduct @sampleProduct, [type]
+      # only masterVariant should be mapped
+      expect(mappedProduct).toEqual [ [ 1, 'var1' ] ]


### PR DESCRIPTION
#### Summary
Resolves #228 

#### Description
This PR adds a new parameter `--onlyMasterVariants` which exports only masterVariants

#### Todo

- Tests
    - [x] Unit
    - [ ] Integration
    - [ ] Acceptance
- [x] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
