### PR TITLE
Handle conflicting attribute names #230

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphere-node-product-csv-sync",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "lint": "grunt coffeelint",
+    "build": "grunt build",
     "watch": "grunt watch:dev",
     "test": "grunt coverage"
   },

--- a/src/coffee/mapping.coffee
+++ b/src/coffee/mapping.coffee
@@ -244,24 +244,30 @@ class Mapping
     variant
 
   mapAttribute: (rawVariant, attribute, languageHeader2Index, rowIndex) ->
-    value = @mapValue rawVariant, attribute, languageHeader2Index, rowIndex
+    # if attribute conflicts with some base product property prefix it with "attribute." string
+    prefixedAttributeName = if attribute.name in CONS.ALL_HEADERS
+      "attribute.#{attribute.name}"
+    else
+      attribute.name
+
+    value = @mapValue rawVariant, prefixedAttributeName, attribute, languageHeader2Index, rowIndex
     return undefined if _.isUndefined(value) or (_.isObject(value) and _.isEmpty(value)) or (_.isString(value) and _.isEmpty(value))
     attribute =
       name: attribute.name
       value: value
     attribute
 
-  mapValue: (rawVariant, attribute, languageHeader2Index, rowIndex) ->
+  mapValue: (rawVariant, attributeName, attribute, languageHeader2Index, rowIndex) ->
     switch attribute.type.name
-      when CONS.ATTRIBUTE_TYPE_SET then @mapSetAttribute rawVariant, attribute.name, attribute.type.elementType, languageHeader2Index, rowIndex
-      when CONS.ATTRIBUTE_TYPE_LTEXT then @mapLocalizedAttrib rawVariant, attribute.name, languageHeader2Index
-      when CONS.ATTRIBUTE_TYPE_NUMBER then @mapNumber rawVariant[@header.toIndex attribute.name], attribute.name, rowIndex
-      when CONS.ATTRIBUTE_TYPE_BOOLEAN then @mapBoolean rawVariant[@header.toIndex attribute.name], attribute.name, rowIndex
-      when CONS.ATTRIBUTE_TYPE_MONEY then @mapMoney rawVariant[@header.toIndex attribute.name], attribute.name, rowIndex
-      when CONS.ATTRIBUTE_TYPE_REFERENCE then @mapReference rawVariant[@header.toIndex attribute.name], attribute, rowIndex
-      when CONS.ATTRIBUTE_TYPE_ENUM then @mapEnumAttribute rawVariant[@header.toIndex attribute.name], attribute.type.values
-      when CONS.ATTRIBUTE_TYPE_LENUM then @mapEnumAttribute rawVariant[@header.toIndex attribute.name], attribute.type.values
-      else rawVariant[@header.toIndex attribute.name] # works for text
+      when CONS.ATTRIBUTE_TYPE_SET then @mapSetAttribute rawVariant, attributeName, attribute.type.elementType, languageHeader2Index, rowIndex
+      when CONS.ATTRIBUTE_TYPE_LTEXT then @mapLocalizedAttrib rawVariant, attributeName, languageHeader2Index
+      when CONS.ATTRIBUTE_TYPE_NUMBER then @mapNumber rawVariant[@header.toIndex attributeName], attribute.name, rowIndex
+      when CONS.ATTRIBUTE_TYPE_BOOLEAN then @mapBoolean rawVariant[@header.toIndex attributeName], attribute.name, rowIndex
+      when CONS.ATTRIBUTE_TYPE_MONEY then @mapMoney rawVariant[@header.toIndex attributeName], attribute.name, rowIndex
+      when CONS.ATTRIBUTE_TYPE_REFERENCE then @mapReference rawVariant[@header.toIndex attributeName], attribute, rowIndex
+      when CONS.ATTRIBUTE_TYPE_ENUM then @mapEnumAttribute rawVariant[@header.toIndex attributeName], attribute.type.values
+      when CONS.ATTRIBUTE_TYPE_LENUM then @mapEnumAttribute rawVariant[@header.toIndex attributeName], attribute.type.values
+      else rawVariant[@header.toIndex attributeName] # works for text
 
   mapEnumAttribute: (enumKey, enumValues) ->
     if enumKey

--- a/src/spec/integration/categoryOrderHint.spec.coffee
+++ b/src/spec/integration/categoryOrderHint.spec.coffee
@@ -220,7 +220,7 @@ describe 'categoryOrderHints', ->
         done()
       .catch (err) -> done.fail _.prettify(err)
 
-    it 'should add categoryOrderHints when using an category name', (done) ->
+    it 'should add categoryOrderHints when using a category name', (done) ->
       service = TestHelpers.createService(project_key, 'products')
       request = {
         uri: service.build()

--- a/src/spec/mapping.spec.coffee
+++ b/src/spec/mapping.spec.coffee
@@ -286,6 +286,31 @@ describe 'Mapping', ->
 
       expect(variant).toEqual expectedVariant
 
+    it 'should map conflicting attribute names', ->
+      productType =
+        name: 'prodType'
+        attributes: [
+          { name: 'attrib', type: { name: 'text' } }
+          { name: 'productType', type: { name: 'text' } }
+        ]
+
+      @map.header = new Header [ 'attrib', 'productType', 'sku', 'variantId', 'attribute.productType' ]
+      @map.header.toIndex()
+      variant = @map.mapVariant [ 'value1', 'prodType', 'mySKU', '9', 'prodTypeAttribValue' ], 9, productType, 77
+
+      expectedVariant =
+        id: 9
+        sku: 'mySKU'
+        prices: []
+        attributes: [{
+          name: 'attrib', value: 'value1'
+        }, {
+          name: 'productType', value: 'prodTypeAttribValue'
+        }]
+        images: []
+
+      expect(variant).toEqual expectedVariant
+
     it 'should take over SameForAll contrainted attribute from master row', ->
       @map.header = new Header [ 'aSame', 'variantId' ]
       @map.header.toIndex()


### PR DESCRIPTION
#### Summary
resolves #230

#### Description
This PR adds a support for importing attributes with conflicting names by prefixing them with `attribute.` string. For example, to import value to attribute named as `productType` the header should be `attribute.productType`. 

#### Todo

- Tests
    - [x] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
