### PR TITLE
fix(product-import): fix import of attributes with conflicting names - eg. attribute.description.en

### DIFF
--- a/src/coffee/header.coffee
+++ b/src/coffee/header.coffee
@@ -69,9 +69,10 @@ class Header
     for langAttribName in localizedAttributes
       for head, index in @rawHeader
         parts = head.split GLOBALS.DELIM_HEADER_LANGUAGE
-        if _.size(parts) is 2
-          if parts[0] is langAttribName
-            lang = parts[1]
+        if _.size(parts) >= 2
+          nameRegexp = new RegExp("^#{langAttribName}\.")
+          if head.match(nameRegexp)
+            lang = _.last(parts)
             # TODO: check language
             langH2i[langAttribName] or= {}
             langH2i[langAttribName][lang] = index
@@ -89,7 +90,11 @@ class Header
         (attribute.type.name is CONS.ATTRIBUTE_TYPE_SET and attribute.type.elementType?.name is CONS.ATTRIBUTE_TYPE_LTEXT) or
         (attribute.type.name is CONS.ATTRIBUTE_TYPE_LENUM) or
         (attribute.type.name is CONS.ATTRIBUTE_TYPE_SET and attribute.type.elementType?.name is CONS.ATTRIBUTE_TYPE_LENUM)
-          attribute.name
+          if attribute.name in CONS.ALL_HEADERS
+            "attribute.#{attribute.name}"
+          else
+            attribute.name
+
       langH2i = @_languageToIndex ptLanguageAttributes
       @productTypeId2HeaderIndex[productType.id] = langH2i
     langH2i

--- a/src/coffee/import.coffee
+++ b/src/coffee/import.coffee
@@ -416,6 +416,12 @@ class Import
         .then (res) -> res.body
     , existingProduct)
 
+  normalizeAttributeName: (name) ->
+    if name in CONS.ALL_HEADERS
+      "attribute.#{name}"
+    else
+      name
+
   update: (product, existingProduct, id2SameForAllAttributes, header, rowIndex, publish) ->
     product.categoryOrderHints = @_mergeCategoryOrderHints existingProduct, product
     if (not product.state? and @defaultState?)
@@ -450,7 +456,7 @@ class Import
       # console.warn "ACTION", action
       switch action.action
         when 'setAttribute', 'setAttributeInAllVariants'
-          (header.has(action.name) or header.hasLanguageForCustomAttribute(action.name)) and not
+          (header.has(@normalizeAttributeName(action.name)) or header.hasLanguageForCustomAttribute(@normalizeAttributeName(action.name))) and not
           @_isBlackListedForUpdate(action.name)
         when 'changeName' then header.has(CONS.HEADER_NAME) or header.hasLanguageForBaseAttribute(CONS.HEADER_NAME)
         when 'changeSlug' then header.has(CONS.HEADER_SLUG) or header.hasLanguageForBaseAttribute(CONS.HEADER_SLUG)

--- a/src/spec/integration/import.spec.coffee
+++ b/src/spec/integration/import.spec.coffee
@@ -75,6 +75,19 @@ describe 'Import integration test', ->
       displayGroup: 'Other'
     })
 
+    @productType.attributes.push({
+      name: 'description'
+      label:
+        en: 'desc'
+      isRequired: false
+      type:
+        name: 'ltext'
+      attributeConstraint: 'None'
+      isSearchable: false
+      inputHint: 'SingleLine'
+      displayGroup: 'Other'
+    })
+
     TestHelpers.setupProductType(@client, @productType, null, project_key)
     .then (result) =>
       @productType = result
@@ -524,10 +537,10 @@ describe 'Import integration test', ->
         expect(result[0]).toBe '[row 2] Product update not necessary.'
         csv =
           """
-          productType,name,variantId,slug,#{LTEXT_ATTRIBUTE_COMBINATION_UNIQUE}.en,#{NUMBER_ATTRIBUTE_COMBINATION_UNIQUE},#{TEXT_ATTRIBUTE_NONE},#{SET_ATTRIBUTE_TEXT_UNIQUE},#{ENUM_ATTRIBUTE_SAME_FOR_ALL},#{REFERENCE_ATTRIBUTE_PRODUCT_TYPE_NONE}
-          #{@productType.id},#{@newProductName},1,#{@newProductSlug},CU1,10,bar,uno;due,enum2
-          ,,2,slug,CU2,10,bar,tre;quattro,enum2,#{@productType.id}
-          ,,3,slug,CU3,10,bar,cinque;sei,enum2,#{@productType.id}
+          productType,name,variantId,slug,#{LTEXT_ATTRIBUTE_COMBINATION_UNIQUE}.en,#{NUMBER_ATTRIBUTE_COMBINATION_UNIQUE},#{TEXT_ATTRIBUTE_NONE},#{SET_ATTRIBUTE_TEXT_UNIQUE},#{ENUM_ATTRIBUTE_SAME_FOR_ALL},#{REFERENCE_ATTRIBUTE_PRODUCT_TYPE_NONE},attribute.description.en,attribute.description.de
+          #{@productType.id},#{@newProductName},1,#{@newProductSlug},CU1,10,bar,uno;due,enum2,,descAttrEn,descAttrDe
+          ,,2,slug,CU2,10,bar,tre;quattro,enum2,#{@productType.id},descAttr1En,descAttr1De
+          ,,3,slug,CU3,10,bar,cinque;sei,enum2,#{@productType.id},descAttr2En,descAttr2De
           """
         im = createImporter()
         im.matchBy = 'slug'
@@ -552,19 +565,22 @@ describe 'Import integration test', ->
         expect(p.masterVariant.attributes[2]).toEqual {name: LTEXT_ATTRIBUTE_COMBINATION_UNIQUE, value: {en: 'CU1'}}
         expect(p.masterVariant.attributes[3]).toEqual {name: NUMBER_ATTRIBUTE_COMBINATION_UNIQUE, value: 10}
         expect(p.masterVariant.attributes[4]).toEqual {name: ENUM_ATTRIBUTE_SAME_FOR_ALL, value: {key: 'enum2', label: 'Enum2'}}
-        expect(p.masterVariant.attributes[5]).toBeUndefined()
+        expect(p.masterVariant.attributes[5]).toEqual {name: 'description', value: { de: 'descAttrDe', en: 'descAttrEn' }}
+        expect(p.masterVariant.attributes[6]).toBeUndefined()
         expect(p.variants[0].attributes[0]).toEqual {name: TEXT_ATTRIBUTE_NONE, value: 'bar'}
         expect(p.variants[0].attributes[1]).toEqual {name: SET_ATTRIBUTE_TEXT_UNIQUE, value: ['tre', 'quattro']}
         expect(p.variants[0].attributes[2]).toEqual {name: LTEXT_ATTRIBUTE_COMBINATION_UNIQUE, value: {en: 'CU2'}}
         expect(p.variants[0].attributes[3]).toEqual {name: NUMBER_ATTRIBUTE_COMBINATION_UNIQUE, value: 10}
         expect(p.variants[0].attributes[4]).toEqual {name: ENUM_ATTRIBUTE_SAME_FOR_ALL, value: {key: 'enum2', label: 'Enum2'}}
         expect(p.variants[0].attributes[5]).toEqual {name: REFERENCE_ATTRIBUTE_PRODUCT_TYPE_NONE, value: {id: @productType.id, typeId: 'product-type'}}
+        expect(p.variants[0].attributes[6]).toEqual {name: 'description', value: { de: 'descAttr1De', en: 'descAttr1En' }}
         expect(p.variants[1].attributes[0]).toEqual {name: TEXT_ATTRIBUTE_NONE, value: 'bar'}
         expect(p.variants[1].attributes[1]).toEqual {name: REFERENCE_ATTRIBUTE_PRODUCT_TYPE_NONE, value: {id: @productType.id, typeId: 'product-type'}}
         expect(p.variants[1].attributes[2]).toEqual {name: SET_ATTRIBUTE_TEXT_UNIQUE, value: ['cinque', 'sei']}
         expect(p.variants[1].attributes[3]).toEqual {name: LTEXT_ATTRIBUTE_COMBINATION_UNIQUE, value: {en: 'CU3'}}
         expect(p.variants[1].attributes[4]).toEqual {name: NUMBER_ATTRIBUTE_COMBINATION_UNIQUE, value: 10}
         expect(p.variants[1].attributes[5]).toEqual {name: ENUM_ATTRIBUTE_SAME_FOR_ALL, value: {key: 'enum2', label: 'Enum2'}}
+        expect(p.variants[1].attributes[6]).toEqual {name: 'description', value: { de: 'descAttr2De', en: 'descAttr2En' }}
         done()
       .catch (err) -> done.fail _.prettify(err)
 


### PR DESCRIPTION
#### Summary
Fixes #236 

#### Description
Fix importing attributes which have a conflicting name (eg `attribute.description`)

#### Todo

- Tests
    - [ ] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
