### PR TITLE
fix(import): add check for matchBy field existence

### DIFF
--- a/src/coffee/import.coffee
+++ b/src/coffee/import.coffee
@@ -126,7 +126,7 @@ class Import
       console.warn "CSV file with #{parsed.count} row(s) loaded."
       @map.header = parsed.header
 
-      if !parsed.header.rawHeader.includes(@matchBy)
+      if !@_isMatchByFieldInHeader(parsed.header.rawHeader, @matchBy)
         return Promise.reject(
           new Error(
             "CSV header does not contain matchBy \"#{@matchBy}\" column.
@@ -156,6 +156,11 @@ class Import
             (p) => @processProducts(p)
           Promise.map(_.batchList(products, @_BATCH_SIZE), p, { concurrency: @_CONCURRENCY })
           .then((results) => _.flatten(results))
+
+  # test whether there is matchBy (slug, id, sku) in header field array eg: sku,slug.en,id,..
+  _isMatchByFieldInHeader: (header, matchBy) ->
+    header.some (field) ->
+      field.split('.')[0].includes(matchBy)
 
   _unarchiveProducts: (archivePath) ->
     tempDir = tmp.dirSync({ unsafeCleanup: true })

--- a/src/coffee/import.coffee
+++ b/src/coffee/import.coffee
@@ -125,6 +125,15 @@ class Import
       parsed = @validator.serialize(parsed)
       console.warn "CSV file with #{parsed.count} row(s) loaded."
       @map.header = parsed.header
+
+      if !parsed.header.rawHeader.includes(@matchBy)
+        return Promise.reject(
+          new Error(
+            "CSV header does not contain matchBy \"#{@matchBy}\" column.
+             Use --matchBy to set different field for finding existing products."
+          )
+        )
+
       @validator.validateOffline(parsed.data)
       if _.size(@validator.errors) isnt 0
         return Promise.reject @validator.errors

--- a/src/spec/integration/import.spec.coffee
+++ b/src/spec/integration/import.spec.coffee
@@ -105,6 +105,23 @@ describe 'Import integration test', ->
       @newProductSku = TestHelpers.uniqueId 'sku-'
       @newProductSku += '"foo"'
 
+    it 'should fail because of a missing matchBy column', (done) ->
+      csv =
+        """
+        productType,name,variantId,slug,key,variantKey
+        #{@productType.id},#{@newProductName},1,#{@newProductSlug},productKey,variantKey
+        """
+      @importer.matchBy = 'id'
+      @importer.import(csv)
+        .then () ->
+          done.fail('Should throw an error')
+        .catch (err) ->
+          expect(err.toString()).toContain(
+            "Error: CSV header does not contain matchBy \"id\" column.
+            Use --matchBy to set different field for finding existing products."
+          )
+          done()
+
     it 'should transition a product state', (done) ->
       csv =
         """


### PR DESCRIPTION
#### Summary
This PR adds a check whether the field specified in `matchBy` column exists in import CSV file. Eg. when matching by `sku`, there should be sku column

Fixes #271 
