### PR TITLE
fix: material value overrides by material type because of substring match

### DIFF
--- a/src/coffee/header.coffee
+++ b/src/coffee/header.coffee
@@ -71,7 +71,7 @@ class Header
         parts = head.split GLOBALS.DELIM_HEADER_LANGUAGE
         if _.size(parts) >= 2
           nameRegexp = new RegExp("^#{langAttribName}\.")
-          if head.match(nameRegexp)
+          if head.match(nameRegexp) && _.first(parts) == langAttribName # because materialType override material attribute because of sub string match
             lang = _.last(parts)
             # TODO: check language
             langH2i[langAttribName] or= {}


### PR DESCRIPTION
#### material value overrides by material type because of substring match

Fixes: #298 